### PR TITLE
Add environment variables and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+SECRET_KEY=your_secret_key
+DB_HOST=your_database_host
+DB_NAME=your_database_name
+DB_USER=your_database_user
+DB_PASSWORD=your_database_password
+DB_PORT=5432
+UPLOAD_FOLDER=static/uploads
+ALLOWED_EXTENSIONS=png,jpg,jpeg,mp4,mov,webm
+MAX_CONTENT_LENGTH=16777216
+MAIL_SERVER=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USERNAME=your_email@example.com
+MAIL_PASSWORD=your_email_password
+MAIL_USE_TLS=True
+MAIL_USE_SSL=False
+MAIL_DEFAULT_SENDER=your_email@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# OOH Tracker
+
+This project tracks out-of-home consumption data using Flask and PostgreSQL.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.env.example` to `.env` and fill in your values.
+3. Run the application:
+   ```bash
+   python app.py
+   ```
+
+## Environment Variables
+
+The application reads configuration from environment variables. Create a `.env` file with the following keys:
+
+```
+SECRET_KEY=your_secret_key
+DB_HOST=your_database_host
+DB_NAME=your_database_name
+DB_USER=your_database_user
+DB_PASSWORD=your_database_password
+DB_PORT=5432
+UPLOAD_FOLDER=static/uploads
+ALLOWED_EXTENSIONS=png,jpg,jpeg,mp4,mov,webm
+MAX_CONTENT_LENGTH=16777216
+MAIL_SERVER=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USERNAME=your_email@example.com
+MAIL_PASSWORD=your_email_password
+MAIL_USE_TLS=True
+MAIL_USE_SSL=False
+MAIL_DEFAULT_SENDER=your_email@example.com
+```
+
+Only `SECRET_KEY`, `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `MAIL_USERNAME`, `MAIL_PASSWORD`, and `MAIL_DEFAULT_SENDER` are strictly required. The rest have sane defaults.

--- a/app.py
+++ b/app.py
@@ -18,6 +18,9 @@ import logging
 import pytz
 import soundfile as sf
 import resampy
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Load Whisper model once at startup (choose 'tiny' for performance)
 whisper_model = whisper.load_model('tiny')
@@ -25,24 +28,24 @@ whisper_model = whisper.load_model('tiny')
 app = Flask(__name__)
 
 # Configuration settings
-app.config['SECRET_KEY'] = 'your_secret_key'  # Change this to a random secret key
-app.config['DB_HOST'] = 'dpg-d1m16indiees7389jq50-a.oregon-postgres.render.com'
-app.config['DB_NAME'] = 'ooh_tracker_db'
-app.config['DB_USER'] = 'ooh_tracker_db_user'
-app.config['DB_PASSWORD'] = 'bZvhR8NpLOxIXQRnSC7qt6tn9Ny7T6jf'
-app.config['DB_PORT'] = '5432'
-app.config['UPLOAD_FOLDER'] = 'static/uploads'
-app.config['ALLOWED_EXTENSIONS'] = {'png', 'jpg', 'jpeg', 'mp4', 'mov', 'webm'}
-app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16MB max upload size
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'change_me')
+app.config['DB_HOST'] = os.environ.get('DB_HOST')
+app.config['DB_NAME'] = os.environ.get('DB_NAME')
+app.config['DB_USER'] = os.environ.get('DB_USER')
+app.config['DB_PASSWORD'] = os.environ.get('DB_PASSWORD')
+app.config['DB_PORT'] = os.environ.get('DB_PORT', '5432')
+app.config['UPLOAD_FOLDER'] = os.environ.get('UPLOAD_FOLDER', 'static/uploads')
+app.config['ALLOWED_EXTENSIONS'] = set(os.environ.get('ALLOWED_EXTENSIONS', 'png,jpg,jpeg,mp4,mov,webm').split(','))
+app.config['MAX_CONTENT_LENGTH'] = int(os.environ.get('MAX_CONTENT_LENGTH', 16 * 1024 * 1024))
 
 # Email configuration settings
-app.config['MAIL_SERVER'] = 'smtp.gmail.com'
-app.config['MAIL_PORT'] = 587
-app.config['MAIL_USERNAME'] = 'seun080ade@gmail.com'
-app.config['MAIL_PASSWORD'] = 'fjfs tlnw smgs rrf'
-app.config['MAIL_USE_TLS'] = True
-app.config['MAIL_USE_SSL'] = False
-app.config['MAIL_DEFAULT_SENDER'] = 'seun080ade@gmail.com'
+app.config['MAIL_SERVER'] = os.environ.get('MAIL_SERVER', 'smtp.gmail.com')
+app.config['MAIL_PORT'] = int(os.environ.get('MAIL_PORT', 587))
+app.config['MAIL_USERNAME'] = os.environ.get('MAIL_USERNAME')
+app.config['MAIL_PASSWORD'] = os.environ.get('MAIL_PASSWORD')
+app.config['MAIL_USE_TLS'] = os.environ.get('MAIL_USE_TLS', 'True').lower() == 'true'
+app.config['MAIL_USE_SSL'] = os.environ.get('MAIL_USE_SSL', 'False').lower() == 'true'
+app.config['MAIL_DEFAULT_SENDER'] = os.environ.get('MAIL_DEFAULT_SENDER')
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- refactor `app.py` to read configuration from environment variables
- add `.gitignore` to keep `.env` files out of version control
- include `.env.example` showing expected variables
- document configuration in a new README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68851d55c388832f944466a44214cf49