### PR TITLE
Improve upload security

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ import logging
 import pytz
 import soundfile as sf
 import resampy
+import magic
 
 # Load Whisper model once at startup (choose 'tiny' for performance)
 whisper_model = whisper.load_model('tiny')
@@ -31,7 +32,7 @@ app.config['DB_NAME'] = 'ooh_tracker_db'
 app.config['DB_USER'] = 'ooh_tracker_db_user'
 app.config['DB_PASSWORD'] = 'bZvhR8NpLOxIXQRnSC7qt6tn9Ny7T6jf'
 app.config['DB_PORT'] = '5432'
-app.config['UPLOAD_FOLDER'] = 'static/uploads'
+app.config['UPLOAD_FOLDER'] = 'uploads'
 app.config['ALLOWED_EXTENSIONS'] = {'png', 'jpg', 'jpeg', 'mp4', 'mov', 'webm'}
 app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16MB max upload size
 
@@ -74,6 +75,32 @@ def login_required(f):
 # Check if the uploaded file is allowed
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in app.config['ALLOWED_EXTENSIONS']
+
+# Validate uploaded files using MIME sniffing and size checks
+ALLOWED_IMAGE_MIME_TYPES = {'image/png', 'image/jpeg'}
+ALLOWED_VIDEO_MIME_TYPES = {'video/mp4', 'video/quicktime', 'video/webm'}
+
+def validate_upload(file, allowed_mime_types):
+    if not file or file.filename == '':
+        return False, 'No file selected'
+
+    if not allowed_file(file.filename):
+        return False, 'Invalid file extension'
+
+    # Check actual file size
+    file.seek(0, os.SEEK_END)
+    size = file.tell()
+    file.seek(0)
+    if size > app.config['MAX_CONTENT_LENGTH']:
+        return False, 'File exceeds size limit'
+
+    # Sniff MIME type from content
+    mime_type = magic.from_buffer(file.read(2048), mime=True)
+    file.seek(0)
+    if mime_type not in allowed_mime_types:
+        return False, 'Invalid file MIME type'
+
+    return True, None
 
 # Mock brand and SKU data (replace with database query if needed)
 def get_brands_and_skus(category):
@@ -365,19 +392,23 @@ def submit_consumption():
 
         if 'photo' in request.files:
             photo = request.files['photo']
-            if photo.filename and allowed_file(photo.filename):
-                filename = secure_filename(f"{uuid.uuid4()}_{photo.filename}")
-                photo_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
-                photo.save(photo_path)
-                photo_path_db = f"uploads/{filename}"
+            valid, error = validate_upload(photo, ALLOWED_IMAGE_MIME_TYPES)
+            if not valid:
+                return jsonify({'success': False, 'message': error}), 400
+            filename = secure_filename(f"{uuid.uuid4()}_{photo.filename}")
+            photo_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+            photo.save(photo_path)
+            photo_path_db = f"uploads/{filename}"
 
         if 'video' in request.files:
             video = request.files['video']
-            if video.filename and allowed_file(video.filename):
-                filename = secure_filename(f"{uuid.uuid4()}_{video.filename}")
-                video_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
-                video.save(video_path)
-                video_path_db = f"uploads/{filename}"
+            valid, error = validate_upload(video, ALLOWED_VIDEO_MIME_TYPES)
+            if not valid:
+                return jsonify({'success': False, 'message': error}), 400
+            filename = secure_filename(f"{uuid.uuid4()}_{video.filename}")
+            video_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
+            video.save(video_path)
+            video_path_db = f"uploads/{filename}"
 
         required_fields = {
             'product_category': product_category,
@@ -451,11 +482,9 @@ def analyze_video():
         return jsonify({'success': False, 'message': 'No video file provided'}), 400
 
     file = request.files['video']
-    if not file or not allowed_file(file.filename):
-        return jsonify({'success': False, 'message': 'Invalid or missing video file'}), 400
-
-    if file.content_length > app.config['MAX_CONTENT_LENGTH']:
-        return jsonify({'success': False, 'message': 'Video exceeds 16MB limit'}), 400
+    valid, error = validate_upload(file, ALLOWED_VIDEO_MIME_TYPES)
+    if not valid:
+        return jsonify({'success': False, 'message': error}), 400
 
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
     filename = secure_filename(f"user_{session['user_id']}_{timestamp}.{file.filename.rsplit('.', 1)[1].lower()}")
@@ -651,8 +680,8 @@ def parse_transcript(transcript):
     
     return data
 
-@app.route('/static/<path:filename>')
-def serve_static(filename):
+@app.route('/uploads/<path:filename>')
+def serve_upload(filename):
     response = send_from_directory(app.config['UPLOAD_FOLDER'], filename)
     response.headers['Cache-Control'] = 'public, max-age=31536000'  # Cache for 1 year
     return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ffmpeg-python
 openai-whisper
 pytz
 resampy
+python-magic


### PR DESCRIPTION
## Summary
- validate uploads with MIME sniffing and size checks
- store uploaded files outside the static folder and serve via a new route
- require `python-magic` for MIME sniffing
- keep an empty placeholder file so the uploads directory exists

## Testing
- `python -m py_compile app.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68851d93c4a4832f8389260d1dd34351