### PR TITLE
Fix magic import

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ import logging
 import pytz
 import soundfile as sf
 import resampy
+import magic
 from dotenv import load_dotenv
 
 load_dotenv()


### PR DESCRIPTION
## Summary
- import `magic` to enable MIME type sniffing in `validate_upload`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688523eac358832f9276a002e0a1ad3d